### PR TITLE
Fix sidebar expansion in overlay

### DIFF
--- a/ui/overlay_window.py
+++ b/ui/overlay_window.py
@@ -34,6 +34,7 @@ class OverlayWindow(QMainWindow):
         self.is_expanded = False
         self.collapsed_width = 60
         self.expanded_width = 350
+        self.expanded_sidebar_width = 220
         
         self.modules = {
             "Levelguide": LevelGuideView(),
@@ -137,7 +138,7 @@ class OverlayWindow(QMainWindow):
         
         if self.is_expanded:
             self.setFixedWidth(self.expanded_width)
-            self.sidebar.setFixedWidth(self.collapsed_width)
+            self.sidebar.setFixedWidth(self.expanded_sidebar_width)
             self.content_area.setVisible(True)
             self.toggle_button.setText("←")
             
@@ -147,6 +148,7 @@ class OverlayWindow(QMainWindow):
                 btn.setFixedSize(200, 40)
         else:
             self.setFixedWidth(self.collapsed_width)
+            self.sidebar.setFixedWidth(self.collapsed_width)
             self.content_area.setVisible(False)
             self.toggle_button.setText("→")
             


### PR DESCRIPTION
## Summary
- make sidebar expand to display module buttons

## Testing
- `python -m py_compile main.py ui/*.py ui/modules/*.py api/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684af9749d60832d8794168d75d98f41