### PR TITLE
Increase sidebar width on expansion

### DIFF
--- a/ui/overlay_window.py
+++ b/ui/overlay_window.py
@@ -137,7 +137,8 @@ class OverlayWindow(QMainWindow):
         
         if self.is_expanded:
             self.setFixedWidth(self.expanded_width)
-            self.sidebar.setFixedWidth(self.collapsed_width)
+            # Expand the sidebar so button text fits within the frame
+            self.sidebar.setFixedWidth(200)
             self.content_area.setVisible(True)
             self.toggle_button.setText("←")
             
@@ -147,6 +148,8 @@ class OverlayWindow(QMainWindow):
                 btn.setFixedSize(200, 40)
         else:
             self.setFixedWidth(self.collapsed_width)
+            # Shrink the sidebar back to its collapsed width
+            self.sidebar.setFixedWidth(self.collapsed_width)
             self.content_area.setVisible(False)
             self.toggle_button.setText("→")
             


### PR DESCRIPTION
## Summary
- widen the sidebar when expanded so text fits

## Testing
- `python -m py_compile ui/overlay_window.py`
- `pip install PyQt6` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684afab50e44832d97509b2ec663f7ad