### PR TITLE
Add LevelGuide tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# ExiledOverlay
+
+This project contains various modules used by an overlay application.
+
+## Running the test suite
+
+The repository uses **pytest** for testing. After installing `pytest` you can
+run the tests from the repository root:
+
+```bash
+pip install pytest
+pytest
+```
+
+The tests currently cover the LevelGuide helper module located under
+`ui.modules.levelguide`.

--- a/tests/test_levelguide.py
+++ b/tests/test_levelguide.py
@@ -1,0 +1,33 @@
+import json
+import os
+import sys
+
+# Ensure the repository root is on the Python path when running "pytest" as an
+# installed command.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from ui.modules.levelguide import LevelGuide
+
+
+def _json_path():
+    return os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "levelguide.json")
+
+
+def test_get_acts_sorted():
+    guide = LevelGuide()
+    acts = guide.get_acts()
+    with open(_json_path(), "r", encoding="utf-8") as f:
+        data = json.load(f)
+    expected = sorted(data.keys(), key=lambda a: int(a.split(" ")[1]))
+    assert acts == expected
+
+
+def test_tasks_for_act_one():
+    guide = LevelGuide()
+    tasks = guide.get_tasks_for_act("Act 1")
+    with open(_json_path(), "r", encoding="utf-8") as f:
+        data = json.load(f)
+    expected = data.get("Act 1")
+    assert isinstance(tasks, list)
+    assert tasks == expected
+    assert len(tasks) > 0


### PR DESCRIPTION
## Summary
- add pytest suite for `LevelGuide`
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afab6a288832d8069fbc70a14da68