### PR TITLE
Implement OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,14 @@ pip install pytest
 pytest
 ```
 
-The tests currently cover the LevelGuide helper module located under
-`ui.modules.levelguide`.
+The tests currently cover the LevelGuide helper module located under `ui.modules.levelguide` and the PoE OAuth helper in `api.poe_auth`.
+
+## Logging into Path of Exile
+
+The overlay uses the official PoE OAuth API for account access. Set the following environment variables before running the application:
+
+- `POE_CLIENT_ID`
+- `POE_CLIENT_SECRET`
+
+During login a browser window will open asking for permission. OAuth tokens are stored in `~/.exiledoverlay_tokens.json` with permissions `600` so only your user can read them.
+

--- a/api/poe_api.py
+++ b/api/poe_api.py
@@ -1,20 +1,23 @@
 # api/poe_api.py
-import requests
+import json
+from urllib import request, parse
 
 def fetch_gear(account_name, character_name, poesessid=None):
     url = "https://api.pathofexile.com/character-window/get-items"
     params = {"accountName": account_name, "character": character_name}
     headers = {
         "User-Agent": "PoE Overlay Tool by Nick",
-        "Accept": "application/json"
+        "Accept": "application/json",
     }
-    cookies = {"POESESSID": poesessid} if poesessid else {}
+    query = parse.urlencode(params)
+    req = request.Request(f"{url}?{query}", headers=headers)
+    if poesessid:
+        req.add_header("Cookie", f"POESESSID={poesessid}")
 
-    response = requests.get(url, params=params, headers=headers, cookies=cookies)
-    if response.status_code != 200:
-        raise Exception(f"Failed to fetch data: {response.status_code} - {response.text}")
-
-    data = response.json()
+    with request.urlopen(req) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Failed to fetch data: {resp.status}")
+        data = json.load(resp)
     gear = {}
     for item in data.get("items", []):
         slot = item.get("inventoryId")

--- a/tests/test_poe_auth.py
+++ b/tests/test_poe_auth.py
@@ -1,0 +1,32 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from api import poe_auth
+
+
+def test_get_token_path(monkeypatch, tmp_path):
+    path = tmp_path / "token.json"
+    monkeypatch.setattr(poe_auth, "TOKEN_FILE", str(path))
+    assert poe_auth._get_token_path() == str(path)
+
+
+def test_save_and_load_token(monkeypatch, tmp_path):
+    path = tmp_path / "token.json"
+    monkeypatch.setattr(poe_auth, "TOKEN_FILE", str(path))
+    token = {"access_token": "abc", "refresh_token": "def"}
+    poe_auth._save_token(token)
+    mode = path.stat().st_mode & 0o777
+    assert mode == 0o600
+    loaded = poe_auth.load_token()
+    assert loaded == token
+
+
+def test_login_env_missing(monkeypatch):
+    monkeypatch.delenv("POE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("POE_CLIENT_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        poe_auth.login()

--- a/ui/gear_view.py
+++ b/ui/gear_view.py
@@ -2,7 +2,7 @@
 from PyQt6.QtWidgets import QWidget, QLabel, QGridLayout, QHBoxLayout, QVBoxLayout
 from PyQt6.QtGui import QPixmap
 from PyQt6.QtCore import Qt
-import requests
+from urllib import request
 from api.poe_api import fetch_gear
 
 def build_item_tooltip(item):
@@ -47,7 +47,8 @@ class GearView(QWidget):
             label = QLabel()
             if item and item.get("icon"):
                 try:
-                    img_data = requests.get(item["icon"]).content
+                    with request.urlopen(item["icon"]) as resp:
+                        img_data = resp.read()
                     pixmap = QPixmap()
                     pixmap.loadFromData(img_data)
                     label.setPixmap(pixmap.scaled(60, 60, Qt.AspectRatioMode.KeepAspectRatio))
@@ -65,7 +66,8 @@ class GearView(QWidget):
             label = QLabel()
             if item and item.get("icon"):
                 try:
-                    img_data = requests.get(item["icon"]).content
+                    with request.urlopen(item["icon"]) as resp:
+                        img_data = resp.read()
                     pixmap = QPixmap()
                     pixmap.loadFromData(img_data)
                     label.setPixmap(pixmap.scaled(40, 60, Qt.AspectRatioMode.KeepAspectRatio))


### PR DESCRIPTION
## Summary
- add PoE OAuth helper for secure logins and token refresh
- fetch API data and images using `urllib` to avoid external deps
- test token storage permissions and environment validation
- document login instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afc8e0ad4832daf75c40887c575c4