### PR TITLE
Add login UI for PoE OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ The overlay uses the official PoE OAuth API for account access. Set the followin
 
 During login a browser window will open asking for permission. OAuth tokens are stored in `~/.exiledoverlay_tokens.json` with permissions `600` so only your user can read them.
 
+Launch the overlay and open the **Account** view to initiate the login flow at any time.
+

--- a/ui/account_view.py
+++ b/ui/account_view.py
@@ -1,0 +1,52 @@
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QLabel, QPushButton, QMessageBox
+)
+from PyQt6.QtCore import Qt
+from api import poe_auth
+
+class AccountView(QWidget):
+    """Simple view for managing PoE account authorization."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._build_ui()
+        self.update_status()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout()
+        layout.setContentsMargins(10, 10, 10, 10)
+
+        title = QLabel("Account")
+        title.setStyleSheet("font-weight: bold; font-size: 16px; color: white;")
+        layout.addWidget(title)
+
+        self.status_label = QLabel()
+        self.status_label.setStyleSheet("color: white;")
+        layout.addWidget(self.status_label)
+
+        self.login_btn = QPushButton()
+        self.login_btn.clicked.connect(self._login)
+        layout.addWidget(self.login_btn)
+
+        layout.addStretch()
+        self.setLayout(layout)
+
+    def update_status(self) -> None:
+        token = poe_auth.load_token()
+        if token:
+            self.status_label.setText("Logged in")
+            self.login_btn.setText("Re-authorize")
+        else:
+            self.status_label.setText("Not logged in")
+            self.login_btn.setText("Log In")
+
+    def _login(self) -> None:
+        try:
+            QMessageBox.information(
+                self, "Login", "A browser window will open for login.")
+            poe_auth.login()
+            QMessageBox.information(
+                self, "Login", "Authorization successful.")
+        except Exception as exc:  # pragma: no cover - integration path
+            QMessageBox.critical(self, "Login Failed", str(exc))
+        self.update_status()

--- a/ui/overlay_window.py
+++ b/ui/overlay_window.py
@@ -11,6 +11,7 @@ from ui.friends_view import FriendsView
 from ui.pob_view import PathOfBuildingView
 from ui.currency_view import CurrencyView
 from ui.tracker_view import TrackerView
+from ui.account_view import AccountView
 
 class OverlayWindow(QMainWindow):
     def __init__(self):
@@ -37,6 +38,7 @@ class OverlayWindow(QMainWindow):
         self.expanded_sidebar_width = 220
         
         self.modules = {
+            "Account": AccountView(),
             "Levelguide": LevelGuideView(),
             "Target Items": TargetItemsView(),
             "Friends": FriendsView(),
@@ -95,6 +97,7 @@ class OverlayWindow(QMainWindow):
 
     def _get_icon_for_module(self, module_name):
         icons = {
+            "Account": "🔑",
             "Levelguide": "📖",
             "Target Items": "🎯",
             "Friends": "👥",


### PR DESCRIPTION
## Summary
- add an `AccountView` that lets the user log in via OAuth
- integrate `AccountView` into `OverlayWindow`
- document how to start login from the overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684afe2b4888832d8bbea9d75672ff0a