### PR TITLE
Improve PoE OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ During login a browser window will open asking for permission. OAuth tokens are 
 
 Launch the overlay and open the **Account** view to initiate the login flow at any time.
 
+Tokens include their expiration time. Use ``poe_auth.ensure_valid_token()`` to
+retrieve a usable token, which will automatically refresh it when needed.
+

--- a/tests/test_poe_auth.py
+++ b/tests/test_poe_auth.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import json
+import time
 
 import pytest
 
@@ -30,3 +32,23 @@ def test_login_env_missing(monkeypatch):
     monkeypatch.delenv("POE_CLIENT_SECRET", raising=False)
     with pytest.raises(RuntimeError):
         poe_auth.login()
+
+
+def test_ensure_valid_token_refresh(monkeypatch, tmp_path):
+    path = tmp_path / "token.json"
+    monkeypatch.setattr(poe_auth, "TOKEN_FILE", str(path))
+
+    expired = {"access_token": "a", "refresh_token": "b", "expires_at": time.time() - 1}
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(expired, f)
+
+    refreshed = {"access_token": "new", "refresh_token": "b", "expires_at": time.time() + 3600}
+
+    def fake_refresh(token):
+        return refreshed
+
+    monkeypatch.setattr(poe_auth, "refresh_token", fake_refresh)
+    monkeypatch.setattr(poe_auth, "login", lambda scope=poe_auth.DEFAULT_SCOPE: refreshed)
+
+    token = poe_auth.ensure_valid_token()
+    assert token == refreshed


### PR DESCRIPTION
## Summary
- handle port collisions and timeouts in login
- validate token responses and track expiry
- add helper to ensure a valid token is available
- document the helper
- test token refresh logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b013b4290832da9cf32cb9d83c428