### PR TITLE
Improve OAuth credential handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ The tests currently cover the LevelGuide helper module located under `ui.modules
 
 ## Logging into Path of Exile
 
-The overlay uses the official PoE OAuth API for account access. Set the following environment variables before running the application:
+The overlay uses the official PoE OAuth API for account access. Register an application on
+[the Path of Exile website](https://www.pathofexile.com/oauth/authorize) to obtain your
+**client id** and, for confidential clients, a **client secret**. Set the following
+environment variables before running the application:
 
-- `POE_CLIENT_ID`
-- `POE_CLIENT_SECRET`
+- `POE_CLIENT_ID` *(required)*
+- `POE_CLIENT_SECRET` *(optional for public clients)*
 
 During login a browser window will open asking for permission. OAuth tokens are stored in `~/.exiledoverlay_tokens.json` with permissions `600` so only your user can read them.
 

--- a/tests/test_poe_auth.py
+++ b/tests/test_poe_auth.py
@@ -27,11 +27,27 @@ def test_save_and_load_token(monkeypatch, tmp_path):
     assert loaded == token
 
 
-def test_login_env_missing(monkeypatch):
+def test_get_client_credentials_missing(monkeypatch):
     monkeypatch.delenv("POE_CLIENT_ID", raising=False)
     monkeypatch.delenv("POE_CLIENT_SECRET", raising=False)
     with pytest.raises(RuntimeError):
-        poe_auth.login()
+        poe_auth._get_client_credentials()
+
+
+def test_get_client_credentials_optional_secret(monkeypatch):
+    monkeypatch.setenv("POE_CLIENT_ID", "abc")
+    monkeypatch.delenv("POE_CLIENT_SECRET", raising=False)
+    cid, secret = poe_auth._get_client_credentials()
+    assert cid == "abc"
+    assert secret is None
+
+
+def test_get_client_credentials_with_secret(monkeypatch):
+    monkeypatch.setenv("POE_CLIENT_ID", "abc")
+    monkeypatch.setenv("POE_CLIENT_SECRET", "xyz")
+    cid, secret = poe_auth._get_client_credentials()
+    assert cid == "abc"
+    assert secret == "xyz"
 
 
 def test_ensure_valid_token_refresh(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- support public clients that have no client secret
- note optional secret in README
- test new credential helper
- ignore build artefacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0550e240832db32eeb4a918a6d42