### PR TITLE
Ensure confidential OAuth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ The tests currently cover the LevelGuide helper module located under `ui.modules
 
 ## Logging into Path of Exile
 
-The overlay uses the official PoE OAuth API for account access. Register an application on
+The overlay uses the official PoE OAuth API for account access. Register a
+**confidential** application on
 [the Path of Exile website](https://www.pathofexile.com/oauth/authorize) to obtain your
-**client id** and, for confidential clients, a **client secret**. Set the following
-environment variables before running the application:
+**client id** and **client secret**. Set the following environment variables
+before running the application:
 
 - `POE_CLIENT_ID` *(required)*
-- `POE_CLIENT_SECRET` *(optional for public clients)*
+- `POE_CLIENT_SECRET` *(required)*
 
 During login a browser window will open asking for permission. OAuth tokens are stored in `~/.exiledoverlay_tokens.json` with permissions `600` so only your user can read them.
 

--- a/api/poe_auth.py
+++ b/api/poe_auth.py
@@ -71,12 +71,18 @@ def load_token() -> dict | None:
         return None
 
 
-def _get_client_credentials() -> tuple[str, str | None]:
-    """Return the configured client id and secret."""
+def _get_client_credentials() -> tuple[str, str]:
+    """Return the configured client id and secret.
+
+    This overlay uses the confidential OAuth client flow which requires both a
+    ``client_id`` and ``client_secret``. If either value is missing a runtime
+    error is raised.
+    """
+
     client_id = os.environ.get("POE_CLIENT_ID")
     client_secret = os.environ.get("POE_CLIENT_SECRET")
-    if not client_id:
-        raise RuntimeError("POE_CLIENT_ID must be set")
+    if not client_id or not client_secret:
+        raise RuntimeError("POE_CLIENT_ID and POE_CLIENT_SECRET must be set")
     return client_id, client_secret
 
 

--- a/tests/test_poe_auth.py
+++ b/tests/test_poe_auth.py
@@ -34,12 +34,11 @@ def test_get_client_credentials_missing(monkeypatch):
         poe_auth._get_client_credentials()
 
 
-def test_get_client_credentials_optional_secret(monkeypatch):
+def test_get_client_credentials_missing_secret(monkeypatch):
     monkeypatch.setenv("POE_CLIENT_ID", "abc")
     monkeypatch.delenv("POE_CLIENT_SECRET", raising=False)
-    cid, secret = poe_auth._get_client_credentials()
-    assert cid == "abc"
-    assert secret is None
+    with pytest.raises(RuntimeError):
+        poe_auth._get_client_credentials()
 
 
 def test_get_client_credentials_with_secret(monkeypatch):


### PR DESCRIPTION
## Summary
- enforce using a confidential OAuth client in `poe_auth`
- update tests to match new requirement
- document required client secret in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0f304920832d8d63ec6ddeb8a230