### PR TITLE
Add currency stash logic

### DIFF
--- a/ui/currency_view.py
+++ b/ui/currency_view.py
@@ -4,6 +4,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt, QTimer
 import json
 import os
+from api import poe_api, poe_auth
 
 class CurrencyView(QWidget):
     def __init__(self):
@@ -90,7 +91,17 @@ class CurrencyView(QWidget):
             row += 1
 
     def refresh_currency(self):
-        # This would connect to PoE API to get actual currency amounts
-        # For now, just reload from file
-        self.currency_data = self.load_currency()
+        """Update currency counts using the PoE API."""
+        try:
+            token = poe_auth.ensure_valid_token("account:stashes")
+            counts = poe_api.fetch_currency(
+                token.get("access_token"),
+                "Standard",
+                list(self.currency_data.keys()),
+            )
+            self.currency_data.update(counts)
+            self.save_currency()
+        except Exception:
+            # Fall back to stored data if anything goes wrong
+            self.currency_data = self.load_currency()
         self.update_display()

--- a/ui/overlay_window.py
+++ b/ui/overlay_window.py
@@ -34,15 +34,9 @@ class OverlayWindow(QMainWindow):
         
         self.is_expanded = False
         self.collapsed_width = 60
-<<<<<<< w73mv5-codex/lokal-credentials-erstellen-und-speichern
-        # Make the expanded overlay smaller so it overlaps the game less while
-        # still leaving enough space for the main views.
-        self.expanded_width = 420
-=======
         # Allow a bit more room for the main view, especially the level guide
         # content which benefits from a wider display.
         self.expanded_width = 500
->>>>>>> main
         self.expanded_sidebar_width = 220
         
         self.modules = {


### PR DESCRIPTION
## Summary
- fix overlay config merge markers
- add PoE stash helper functions and implement currency fetching
- connect the Currency view to the new API helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c77b94fc0832da572eeaf3115a448