### PR TITLE
Add currency stash logic

### DIFF
--- a/api/poe_api.py
+++ b/api/poe_api.py
@@ -30,3 +30,53 @@ def fetch_gear(account_name, character_name, poesessid=None):
             "explicitMods": item.get("explicitMods", [])
         }
     return gear
+
+
+def _api_request(url, token=None):
+    """Internal helper to perform an authenticated GET request."""
+    headers = {
+        "User-Agent": "ExiledOverlay",
+        "Accept": "application/json",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = request.Request(url, headers=headers)
+    with request.urlopen(req) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Failed request: {resp.status}")
+        return json.load(resp)
+
+
+def fetch_currency(token, league, currencies):
+    """Return currency counts for the logged in account."""
+    base = "https://api.pathofexile.com"
+    tabs_url = f"{base}/profile/stash-tabs?league={parse.quote(league)}"
+    data = _api_request(tabs_url, token)
+    tab_ids = [t["id"] for t in data.get("tabs", [])]
+
+    counts = {c: 0 for c in currencies}
+    for tab_id in tab_ids:
+        items_url = f"{base}/stash/{tab_id}?league={parse.quote(league)}"
+        tab_data = _api_request(items_url, token)
+        for item in tab_data.get("items", []):
+            name = item.get("typeLine")
+            if name in counts:
+                counts[name] += int(item.get("stackSize", 1))
+    return counts
+
+
+def fetch_item_count(token, league, item_name):
+    """Return the total count of ``item_name`` across all stashes."""
+    base = "https://api.pathofexile.com"
+    tabs_url = f"{base}/profile/stash-tabs?league={parse.quote(league)}"
+    data = _api_request(tabs_url, token)
+    tab_ids = [t["id"] for t in data.get("tabs", [])]
+
+    total = 0
+    for tab_id in tab_ids:
+        items_url = f"{base}/stash/{tab_id}?league={parse.quote(league)}"
+        tab_data = _api_request(items_url, token)
+        for item in tab_data.get("items", []):
+            if item.get("typeLine") == item_name or item.get("name") == item_name:
+                total += int(item.get("stackSize", 1))
+    return total

--- a/ui/currency_view.py
+++ b/ui/currency_view.py
@@ -4,6 +4,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import Qt, QTimer
 import json
 import os
+from api import poe_api, poe_auth
 
 class CurrencyView(QWidget):
     def __init__(self):
@@ -90,7 +91,17 @@ class CurrencyView(QWidget):
             row += 1
 
     def refresh_currency(self):
-        # This would connect to PoE API to get actual currency amounts
-        # For now, just reload from file
-        self.currency_data = self.load_currency()
+        """Update currency counts using the PoE API."""
+        try:
+            token = poe_auth.ensure_valid_token("account:stashes")
+            counts = poe_api.fetch_currency(
+                token.get("access_token"),
+                "Standard",
+                list(self.currency_data.keys()),
+            )
+            self.currency_data.update(counts)
+            self.save_currency()
+        except Exception:
+            # Fall back to stored data if anything goes wrong
+            self.currency_data = self.load_currency()
         self.update_display()

--- a/ui/overlay_window.py
+++ b/ui/overlay_window.py
@@ -34,15 +34,9 @@ class OverlayWindow(QMainWindow):
         
         self.is_expanded = False
         self.collapsed_width = 60
-<<<<<<< w73mv5-codex/lokal-credentials-erstellen-und-speichern
-        # Make the expanded overlay smaller so it overlaps the game less while
-        # still leaving enough space for the main views.
-        self.expanded_width = 420
-=======
         # Allow a bit more room for the main view, especially the level guide
         # content which benefits from a wider display.
         self.expanded_width = 500
->>>>>>> main
         self.expanded_sidebar_width = 220
         
         self.modules = {

--- a/ui/tracker_view.py
+++ b/ui/tracker_view.py
@@ -1,8 +1,9 @@
 from PyQt6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, 
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
     QPushButton, QSpinBox, QListWidget, QListWidgetItem
 )
 from PyQt6.QtCore import Qt
+from api import poe_auth, poe_api
 import json
 import os
 
@@ -101,10 +102,21 @@ class TrackerView(QWidget):
     def add_tracker(self):
         item_name = self.item_input.text().strip()
         if item_name:
+            count = self.count_input.value()
+            try:
+                token = poe_auth.ensure_valid_token("account:stashes")
+                count = poe_api.fetch_item_count(
+                    token.get("access_token"),
+                    "Standard",
+                    item_name,
+                )
+            except Exception:
+                # Fall back to user provided value on error
+                pass
             tracker = {
                 "item": item_name,
-                "current": self.count_input.value(),
-                "target": self.target_input.value()
+                "current": count,
+                "target": self.target_input.value(),
             }
             self.trackers.append(tracker)
             self.save_trackers()
@@ -151,5 +163,5 @@ class TrackerView(QWidget):
             self.refresh_list()
 
     def edit_tracker(self, item):
-        # Double-click to increment by 1
+        """Double-click to increment the selected tracker by 1."""
         self.modify_selected(1)


### PR DESCRIPTION
## Summary
- fix overlay config merge markers
- add PoE stash helper functions and implement currency fetching
- connect the Currency view to the new API helpers
- implement tracker logic to look up item counts in stashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c77b94fc0832da572eeaf3115a448